### PR TITLE
(ci) Add lint workflow, update build workflow actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: stable
+        go-version: '1.25'
 
     - name: Build
       run: go build -o discard -v ./cli

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,23 +4,19 @@
 name: Go
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    types: [opened, synchronize, edited, ready_for_review, review_requested]
-    branches: [ "main" ]
+  [push, pull_request]
 
 jobs:
 
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: stable
 
     - name: Build
       run: go build -o discard -v ./cli

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,20 @@
+name: golangci-lint
+on:
+  [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11


### PR DESCRIPTION
You know the drill, adds a lint workflow for pushes and PRs, updates build workflow actions to Node 24.